### PR TITLE
Add mapping for arrow

### DIFF
--- a/ftplugin/pie.vim
+++ b/ftplugin/pie.vim
@@ -6,3 +6,4 @@ let g:loaded_pie_pluing = 1
 inoremap <buffer> \Pi Π
 inoremap <buffer> \l λ
 inoremap <buffer> \sum Σ
+inoremap <buffer> \ar →


### PR DESCRIPTION
I like the idea of the mappings, I added one for `→` to help with type definitions.

I also find `\Pi` a bit tricky to type and would prefer `\pi`, but I wasn't sure if that was amenable to you.